### PR TITLE
BUG: Fix template finding

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include beancount_web/templates *
+recursive-include beancount_web/static *
+

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='beancount-web',
             'livereload',
             'Pygments'
       ],
+      include_package_data=True,
       dependency_links=[
             'hg+https://bitbucket.org/blais/beancount#egg=beancount',
             'git+ssh://git@github.com/aumayr/beancount-pygments-lexer.git#egg=beancount_pygments_lexer'


### PR DESCRIPTION
Figured out the problem.  It was just that setup.py wasn't copying the templates when installing.  You were probably doing python setup.py develop, which wouldn't have had this issue.

Solution as per: http://flask.pocoo.org/docs/0.10/patterns/distribute/

It doesn't need the commit you put in the Try to fix branch.