### PR TITLE
Updated beancount_web.api to follow changes to render_entry_context.

### DIFF
--- a/beancount_web/api.py
+++ b/beancount_web/api.py
@@ -540,8 +540,7 @@ class BeancountReportAPI(object):
 
         for entry in matching_entries:
             context_str = context.render_entry_context(
-                self.entries, self.options_map, dcontext,
-                entry.meta["filename"], entry.meta["lineno"])
+                self.entries, self.options_map, entry)
 
             hash_ = context_str.split("\n",2)[0].split(':')[1].strip()
             filenamelineno = context_str.split("\n",2)[1]


### PR DESCRIPTION
The default branch of Beancount has had an API change on render_entry_context.
This updates your project to the change.
Test and merge at your convenience.
