### PR TITLE
reduce redundancy in application.py

### DIFF
--- a/beancount_web/api.py
+++ b/beancount_web/api.py
@@ -54,6 +54,8 @@ class BeancountReportAPI(object):
         self.entries, self._errors, self.options = loader.load_file(self.beancount_file_path)
         self.all_entries = self.entries
 
+        self.title = self.options['title']
+
         self.errors = []
         for error in self._errors:
             self.errors.append({
@@ -68,6 +70,7 @@ class BeancountReportAPI(object):
 
         self.account_types = options.get_account_types(self.options)
         self.real_accounts = realization.realize(self.entries, self.account_types)
+        self.all_accounts = self._account_components()
 
     def filter(self, year=None, tag=None):
         if year:
@@ -489,9 +492,6 @@ class BeancountReportAPI(object):
         postings = realization.get_postings(self.real_accounts)
         return self._journal_for_postings(postings, Document)
 
-    def title(self):
-        return self.options['title']
-
     def holdings(self):
         return holdings_reports.report_holdings(None, False, self.entries, self.options)
 
@@ -582,10 +582,6 @@ class BeancountReportAPI(object):
             'balances': self.balances(account_name),
             'modifier': get_account_sign(account_name, self.account_types),
         }
-
-    def active_components(self):
-        # TODO rename?
-        return self._account_components()
 
     def monthly_totals(self, account_name):
         real_account = realization.get(self.real_accounts, account_name)

--- a/beancount_web/api.py
+++ b/beancount_web/api.py
@@ -45,22 +45,36 @@ class BeancountReportAPI(object):
         self.load_file()
 
     def load_file(self):
+        """Load self.beancount_file_path and compute things that are independent
+        of how the entries might be filtered later"""
         with open(self.beancount_file_path, encoding='utf8') as f:
-            self._source = f.read()
+            self.source = f.read()
 
-        self.entries, self._errors, self.options_map = loader.load_file(self.beancount_file_path)
+        self.entries, self._errors, self.options = loader.load_file(self.beancount_file_path)
         self.all_entries = self.entries
 
-        self.account_types = options.get_account_types(self.options_map)
+        self.errors = []
+        for error in self._errors:
+            self.errors.append({
+                'file': error.source['filename'],
+                'line': error.source['lineno'],
+                'error': error.message,
+                'entry': error.entry  # TODO render entry
+            })
+
+        self.active_years = list(getters.get_active_years(self.all_entries))
+        self.active_tags = list(getters.get_all_tags(self.all_entries))
+
+        self.account_types = options.get_account_types(self.options)
         self.real_accounts = realization.realize(self.entries, self.account_types)
 
     def filter(self, year=None, tag=None):
         if year:
-            yv = YearView(self.all_entries, self.options_map, str(year), year)
+            yv = YearView(self.all_entries, self.options, str(year), year)
             self.entries = yv.entries
 
         if tag:
-            tv = TagView(self.all_entries, self.options_map, tag, set([tag]))
+            tv = TagView(self.all_entries, self.options, tag, set([tag]))
             self.entries = tv.entries
 
         self.real_accounts = realization.realize(self.entries, self.account_types)
@@ -130,7 +144,7 @@ class BeancountReportAPI(object):
                 line['balances'][pos.lot.currency] = pos.number
 
             # Accounts that are not leafs but have entries are leafs as well
-            for currency in self.options_map['commodities']:
+            for currency in self.options['commodities']:
                 if currency in line['balances'] and currency in line['balances_children']:
                     if line['balances'][currency] != line['balances_children'][currency]:
                         line['is_leaf'] = True
@@ -306,10 +320,10 @@ class BeancountReportAPI(object):
         monthly_totals = []
         for begin_date, end_date in month_tuples:
             entries, index = summarize.clamp_opt(self.entries, begin_date, end_date + timedelta(days=1),
-                                                          self.options_map)
+                                                          self.options)
 
-            income_totals = self._table_totals(realization.get(realization.realize(entries, self.account_types), self.options_map['name_income']))
-            expenses_totals = self._table_totals(realization.get(realization.realize(entries, self.account_types), self.options_map['name_expenses']))
+            income_totals = self._table_totals(realization.get(realization.realize(entries, self.account_types), self.options['name_income']))
+            expenses_totals = self._table_totals(realization.get(realization.realize(entries, self.account_types), self.options['name_expenses']))
 
             # FIXME find better way to only include relevant totals (lots of ZERO-ones at the beginning)
             sum_ = ZERO
@@ -378,7 +392,7 @@ class BeancountReportAPI(object):
             end_date_ = end_date
 
         entries, index = summarize.clamp_opt(self.entries, begin_date_, end_date_ + timedelta(days=1),
-                                                     self.options_map)
+                                                     self.options)
 
         real_accounts = realization.get(realization.realize(entries, self.account_types), account_name)
 
@@ -430,7 +444,7 @@ class BeancountReportAPI(object):
         account_names = [account['full_name'] for account in self._account_components() if account['full_name'].startswith(account_name)]
 
         month_tuples = self._month_tuples(self.entries)
-        monthly_totals = { end_date.isoformat(): { currency: ZERO for currency in self.options_map['commodities']} for begin_date, end_date in month_tuples }
+        monthly_totals = { end_date.isoformat(): { currency: ZERO for currency in self.options['commodities']} for begin_date, end_date in month_tuples }
 
         arr = { account_name: {} for account_name in account_names }
 
@@ -461,19 +475,6 @@ class BeancountReportAPI(object):
     def trial_balance(self):
         return self._table_tree(self.real_accounts)[1:]
 
-    def errors(self):
-        errors = []
-
-        for error in self._errors:
-            errors.append({
-                'file': error.source['filename'],
-                'line': error.source['lineno'],
-                'error': error.message,
-                'entry': error.entry  # TODO render entry
-            })
-
-        return errors
-
     def journal(self, account_name=None):
         if account_name:
             real_account = realization.get(self.real_accounts, account_name)
@@ -488,10 +489,10 @@ class BeancountReportAPI(object):
         return self._journal_for_postings(postings, Document)
 
     def title(self):
-        return self.options_map['title']
+        return self.options['title']
 
     def holdings(self):
-        return holdings_reports.report_holdings(None, False, self.entries, self.options_map)
+        return holdings_reports.report_holdings(None, False, self.entries, self.options)
 
     def _net_worth_in_periods(self):
         month_tuples = self._month_tuples(self.entries)
@@ -501,9 +502,9 @@ class BeancountReportAPI(object):
 
         for begin_date, end_date in month_tuples:
             entries, index = summarize.clamp_opt(self.entries, date_start, end_date + timedelta(days=1),
-                                                          self.options_map)
+                                                          self.options)
 
-            networth_as_table = networthtable.generate_table(entries, self.errors, self.options_map)
+            networth_as_table = networthtable.generate_table(entries, self.errors, self.options)
 
             totals = dict(networth_as_table[2])
             for key, value in totals.items():
@@ -519,7 +520,7 @@ class BeancountReportAPI(object):
 
     def net_worth(self):
         networth_report = holdings_reports.NetWorthReport(None, None)
-        networth_as_table = networth_report.generate_table(self.entries, self.errors, self.options_map)
+        networth_as_table = networth_report.generate_table(self.entries, self.errors, self.options)
 
         current_net_worth = dict(networth_as_table[2])
         for key, value in current_net_worth.items():
@@ -536,11 +537,11 @@ class BeancountReportAPI(object):
                                 if ehash == compare.hash_entry(entry)]
 
         contexts = []
-        dcontext = self.options_map['dcontext']
+        dcontext = self.options['dcontext']
 
         for entry in matching_entries:
             context_str = context.render_entry_context(
-                self.entries, self.options_map, entry)
+                self.entries, self.options, entry)
 
             hash_ = context_str.split("\n",2)[0].split(':')[1].strip()
             filenamelineno = context_str.split("\n",2)[1]
@@ -574,22 +575,10 @@ class BeancountReportAPI(object):
             'journal': self._journal_for_postings(matching_entries)
         }
 
-    def active_years(self):
-        return list(getters.get_active_years(self.all_entries))
-
-    def active_tags(self):
-        return list(getters.get_all_tags(self.all_entries))
-
     def active_components(self):
         # TODO rename?
         return self._account_components()
 
-    def source(self):
-        return self._source
-
     def monthly_totals(self, account_name):
         real_account = realization.get(self.real_accounts, account_name)
         return self._monthly_totals(real_account.account, self.entries)
-
-    def options(self):
-        return self.options_map

--- a/beancount_web/api.py
+++ b/beancount_web/api.py
@@ -11,6 +11,7 @@ from beancount.parser import options
 from beancount.core import compare
 from beancount.core.number import ZERO
 from beancount.core.data import Open, Close, Note, Document, Balance, TxnPosting, Transaction, Pad  # TODO implement missing
+from beancount.core.account_types import get_account_sign
 from beancount.reports import holdings_reports
 from beancount.core import getters
 from beancount.web.views import YearView, TagView
@@ -573,6 +574,13 @@ class BeancountReportAPI(object):
             'hash': ehash,
             'contexts': contexts,
             'journal': self._journal_for_postings(matching_entries)
+        }
+
+    def treemap_data(self, account_name):
+        return {
+            'label': account_name,
+            'balances': self.balances(account_name),
+            'modifier': get_account_sign(account_name, self.account_types),
         }
 
     def active_components(self):

--- a/beancount_web/application.py
+++ b/beancount_web/application.py
@@ -141,10 +141,7 @@ def inject_errors():
     return dict(errors=app.api.errors,
                 api=app.api,
                 options=options,
-                title=app.api.title(),
-                active_years=app.api.active_years,
-                active_tags=app.api.active_tags,
-                active_components=app.api.active_components(),
+                title=app.api.title,
                 operating_currencies=options['operating_currency'],
                 commodities=options['commodities'])
 

--- a/beancount_web/application.py
+++ b/beancount_web/application.py
@@ -36,13 +36,7 @@ def account(account_name=None, with_journal=False, with_monthly_balances=False):
                     'change': journal_entry['change'],
                 })
 
-        treemap_data = {
-            'label': 'Subaccounts',
-            'balances': app.api.balances(account_name),
-            'modifier': 1  # TODO find out via API?
-        }
-
-        return render_template('account.html', account_name=account_name, journal=journal, linechart_data=linechart_data, monthly_totals=monthly_totals, treemap_data=treemap_data)
+        return render_template('account.html', account_name=account_name, journal=journal, linechart_data=linechart_data, monthly_totals=monthly_totals)
 
     if with_monthly_balances:
         monthly_balances = app.api.monthly_balances(account_name)
@@ -65,34 +59,6 @@ def account(account_name=None, with_journal=False, with_monthly_balances=False):
 @app.route('/')
 def index():
     return redirect(url_for('report', report_name='balance_sheet'))
-
-@app.route('/trial_balance/')
-def trial_balance():
-    treemap_balances = []
-    treemap_balances.append({
-        'label': app.api.options['name_expenses'],
-        'balances': app.api.balances(app.api.options['name_expenses'])
-    })
-    treemap_balances.append({
-        'label': app.api.options['name_income'],
-        'balances': app.api.balances(app.api.options['name_income']),
-        'modifier': -1
-    })
-    treemap_balances.append({
-        'label': app.api.options['name_assets'],
-        'balances': app.api.balances(app.api.options['name_assets'])
-    })
-    treemap_balances.append({
-        'label': app.api.options['name_equity'],
-        'balances': app.api.balances(app.api.options['name_equity']),
-        'modifier': -1
-    })
-    treemap_balances.append({
-        'label': app.api.options['name_liabilities'],
-        'balances': app.api.balances(app.api.options['name_liabilities'])
-    })
-
-    return render_template('trial_balance.html', treemap_balances=treemap_balances)
 
 @app.route('/context/<ehash>/')
 def context(ehash=None):
@@ -126,6 +92,7 @@ def report(report_name):
             'holdings',
             'options',
             'net_worth',
+            'trial_balance',
     ]:
         return render_template('{}.html'.format(report_name))
     return redirect(url_for('report', report_name='balance_sheet'))

--- a/beancount_web/templates/_layout.html
+++ b/beancount_web/templates/_layout.html
@@ -40,7 +40,7 @@
                                 <input type="search">
                             </div>
                             <ul>
-                                {% for year in active_years -%}
+                                {% for year in api.active_years -%}
                                 <li><a href="{{ request.path }}?filter_year={{ year }}">{{ year }}</a></li>
                                 {% endfor -%}
                             </ul>
@@ -53,7 +53,7 @@
                                 <input type="search">
                             </div>
                             <ul>
-                                {% for tag in active_tags -%}
+                                {% for tag in api.active_tags -%}
                                 <li><a href="{{ request.path }}?filter_tag={{ tag }}"># {{ tag }}</a></li>
                                 {% endfor -%}
                             </ul>
@@ -66,7 +66,7 @@
                                 <input type="search">
                             </div>
                             <ul>
-                                {% for component in active_components -%}
+                                {% for component in api.all_accounts -%}
                                 <li><a href="{{ url_for('account_with_journal', name=component.full_name) }}" title="{{ component.full_name }}">{% for i in range(component.depth) %}&ndash;{% endfor %}&nbsp;{{ component.name }}</a></li>
                                 {% endfor -%}
                             </ul>

--- a/beancount_web/templates/account.html
+++ b/beancount_web/templates/account.html
@@ -34,6 +34,7 @@
         {% with monthly_totals = monthly_totals %}
             {% include "charts/_chart_monthly_totals.html" %}
         {% endwith %}
+        {% set treemap_data = api.treemap_data(account_name) %}
         {% with label=treemap_data.label, rows=treemap_data.balances, modifier=treemap_data.modifier, level=account_name.split(':')|length %}
             {% include "charts/_chart_treemap.html" %}
         {% endwith %}

--- a/beancount_web/templates/balance_sheet.html
+++ b/beancount_web/templates/balance_sheet.html
@@ -5,6 +5,10 @@
 
 {% block content %}
     <h1>Balance Sheet</h1>
+    {% set assets = api.balances(api.options['name_assets']) %}
+    {% set liabilities = api.balances(api.options['name_liabilities']) %}
+    {% set equity = api.balances(api.options['name_equity']) %}
+    {% set net_worth = api.net_worth() %}
 
     {% include "charts/_chart_skeleton.html" %}
     {% include "charts/_chart_monthly_net_worth.html" %}

--- a/beancount_web/templates/documents.html
+++ b/beancount_web/templates/documents.html
@@ -5,6 +5,7 @@
 
 {% block content %}
     <h1>Documents</h1>
+    {% set documents = api.documents() %}
     {% if documents %}
         {% with journal=documents %}
             {% include "_journal_table.html" %}

--- a/beancount_web/templates/holdings.html
+++ b/beancount_web/templates/holdings.html
@@ -4,6 +4,7 @@
 {% block title %}Equity/Holdings{% endblock %}
 
 {% block content %}
+    {% set holdings = api.holdings() %}
     <h1>Equity/Holdings</h1>
     <table class="holdings">
       <thead>

--- a/beancount_web/templates/income_statement.html
+++ b/beancount_web/templates/income_statement.html
@@ -5,7 +5,12 @@
 
 {% block content %}
     <h1>Income Statement</h1>
-
+    {% set income = api.balances(options['name_income']) %}
+    {% set expenses = api.balances(options['name_expenses']) %}
+    {% set income_monthly_totals = api.monthly_totals(options['name_income']) %}
+    {% set expenses_monthly_totals = api.monthly_totals(options['name_expenses']) %}
+    {# TODO calls api.monthly_totals twice for income and expenses#}
+    {% set monthly_totals = api.monthly_income_expenses_totals() %}
     {% include "charts/_chart_skeleton.html" %}
     {# {% with .monthly_totals  %} #}
         {% include "charts/_chart_monthly_ie_changes.html" %}

--- a/beancount_web/templates/journal.html
+++ b/beancount_web/templates/journal.html
@@ -5,6 +5,7 @@
 
 {% block content %}
     <h1>General Ledger</h1>
+    {% set journal = api.journal() %}
     {% with show_tablefilter=True  %}
         {% include "_journal_table.html" %}
     {% endwith %}

--- a/beancount_web/templates/net_worth.html
+++ b/beancount_web/templates/net_worth.html
@@ -5,10 +5,9 @@
 
 {% block content %}
     <h1>Net Worth</h1>
-
+    {% set net_worth = api.net_worth() %}
     {% include "charts/_chart_skeleton.html" %}
     {% include "charts/_chart_monthly_net_worth.html" %}
-
     <table class="net_worth">
         <thead>
             <tr>

--- a/beancount_web/templates/trial_balance.html
+++ b/beancount_web/templates/trial_balance.html
@@ -9,7 +9,8 @@
 
     {% include "charts/_chart_skeleton.html" %}
 
-    {% for balance in treemap_balances %}
+    {% for base_account in ['expenses', 'income', 'assets', 'equity', 'liabilities'] %}
+        {% set balance = api.treemap_data(options['name_{}'.format(base_account)]) %}
         {% with label=balance.label, rows=balance.balances, modifier=balance.modifier %}
             {% include "charts/_chart_treemap.html" %}
         {% endwith %}

--- a/beancount_web/templates/trial_balance.html
+++ b/beancount_web/templates/trial_balance.html
@@ -5,6 +5,7 @@
 
 {% block content %}
     <h1>Trial Balance</h1>
+    {% set trial_balance = api.trial_balance() %}
 
     {% include "charts/_chart_skeleton.html" %}
 


### PR DESCRIPTION
The templates for most of the reports already contain all the logic of
what parts of the api they need. So pass the api along to the template
context and compute whatever is needed there.

Also, compute api attributes that are independent of the filters applied as soon as the file is loaded. Less computations on page load...