### PR TITLE
Dateparser

### DIFF
--- a/beancount_web/api.py
+++ b/beancount_web/api.py
@@ -199,9 +199,12 @@ class BeancountReportAPI(object):
         self.active_years = list(getters.get_active_years(self.all_entries))
         self.active_tags = list(getters.get_all_tags(self.all_entries))
         self.active_payees = list(getters.get_all_payees(self.all_entries))
+        self.apply_filters()
 
+    def apply_filters(self):
         if self.filter_year:
             begin_date, end_date = parse_date(self.filter_year)
+            self.entries = self.all_entries
             self.entries = self._entries_in_inclusive_range(begin_date, end_date-timedelta(days=1))
 
         if self.filter_tags:
@@ -232,7 +235,7 @@ class BeancountReportAPI(object):
         self.filter_tags = tags
         self.filter_account = account
         self.filter_payees = payees
-        self.load_file()
+        self.apply_filters()
 
     def _account_components(self):
         # TODO rename

--- a/beancount_web/api.py
+++ b/beancount_web/api.py
@@ -10,7 +10,6 @@ from beancount.reports import context
 from beancount.utils import bisect_key
 from beancount.core import realization, flags
 from beancount.core import interpolate
-from beancount.web.views import AllView
 from beancount.parser import options
 from beancount.core import compare
 from beancount.core.account import has_component
@@ -24,6 +23,8 @@ from beancount.ops.holdings import Holding
 from beancount.utils import misc_utils
 from beancount.core.realization import RealAccount, find_last_active_posting
 from beancount.core.data import get_entry
+
+from beancount_web.util.dateparser import parse_date
 
 # This really belongs in beancount:src/python/beancount/ops/holdings.py
 def get_holding_from_position(lot, number, account=None, price_map=None, date=None):
@@ -200,9 +201,8 @@ class BeancountReportAPI(object):
         self.active_payees = list(getters.get_all_payees(self.all_entries))
 
         if self.filter_year:
-            begin_date = date(self.filter_year, 1, 1)
-            end_date = date(self.filter_year+1, 1, 1)
-            self.entries = self._entries_in_inclusive_range(begin_date, end_date)
+            begin_date, end_date = parse_date(self.filter_year)
+            self.entries = self._entries_in_inclusive_range(begin_date, end_date-timedelta(days=1))
 
         if self.filter_tags:
             self.entries = [entry

--- a/beancount_web/application.py
+++ b/beancount_web/application.py
@@ -171,7 +171,7 @@ def perform_global_filters():
         if filter_year == "":
             app.entry_filters.pop('year', None)
         else:
-            app.entry_filters['year'] = int(filter_year)
+            app.entry_filters['year'] = filter_year
 
     filter_tag = request.args.get('filter_tag', None)
     if filter_tag != None:

--- a/beancount_web/util/dateparser.py
+++ b/beancount_web/util/dateparser.py
@@ -10,12 +10,11 @@ all_months = months[1:] + months_abbr[1:]
 rel_dates = {'yesterday': -1, 'today': 0, 'tomorrow': 1}
 modifiers = {'this': 0, 'next': 1, 'last': -1}
 
-is_range_re = re.compile('(?:from )?(.*?)\s(?:-|to)\s(.*)')
+is_range_re = re.compile('(.*?)\s(?:-|to)\s(.*)')
 
-# this matches dates of the form 'year-month-day' (. instead of - is possible)
+# this matches dates of the form 'year-month-day'
 # day or month and day may be omitted
-year_first_re = re.compile('^(\d{4})(?:[.-](\d{2}))?(?:[.-](\d{2}))?$')
-
+year_first_re = re.compile('^(\d{4})(?:-(\d{2}))?(?:-(\d{2}))?$')
 
 # this will match any date of the form "day month_name year".
 year_last_re = re.compile('^(?:{1} )?'
@@ -33,7 +32,7 @@ mod_date_re = re.compile('(?:({}) )?({}) ({})'.format(
 
 def daterange(year=None, month=None, day=None, timedelta=datetime.timedelta()):
     """A helper function that returns a tuple with the starting and end date for
-    for the given range of dates. If called with empty arguments it will return
+    the given range of dates. If called with empty arguments it will return
     the current day as start and beginning. Otherwise day or month and day may
     be omitted to get the whole month or whole year respectively. Timedelta is
     only used if all other arguments are none and if it is set the dates that
@@ -70,14 +69,13 @@ def parse_date(string):
 
     Example of supported formats:
      - today, tomorrow, yesterday
-     - 2010-03-15, 2010.03, 2010 ('.' and '-' are possible delimiters)
+     - 2010-03-15, 2010-03, 2010
      - march 2010, mar 2010
      - this month, last year, next year
      - october this year, aug last year
 
     Ranges of dates can be expressed in the following forms:
      - start - end
-     - from start to end
      - start to end
     where start and end look like one of the above examples
     """
@@ -134,6 +132,8 @@ if __name__ == '__main__':
         'august next year': daterange(today.year + 1, 8),
         '2nd aug, 2010': daterange(2010, 8, 2),
         'august 3rd, 2012': daterange(2012, 8, 3),
+        '2014 to 2015': (daterange(2014)[0], daterange(2015)[1]),
+        '2011-10 - 2015': (daterange(2011, 10)[0], daterange(2015)[1]),
     }
     for test, result in tests.items():
         assert parse_date(test) == result

--- a/beancount_web/util/dateparser.py
+++ b/beancount_web/util/dateparser.py
@@ -1,0 +1,140 @@
+import re
+import datetime
+import calendar
+
+
+months = [m.lower() for m in calendar.month_name]
+months_abbr = [m.lower() for m in calendar.month_abbr]
+all_months = months[1:] + months_abbr[1:]
+
+rel_dates = {'yesterday': -1, 'today': 0, 'tomorrow': 1}
+modifiers = {'this': 0, 'next': 1, 'last': -1}
+
+is_range_re = re.compile('(?:from )?(.*?)\s(?:-|to)\s(.*)')
+
+# this matches dates of the form 'year-month-day' (. instead of - is possible)
+# day or month and day may be omitted
+year_first_re = re.compile('^(\d{4})(?:[.-](\d{2}))?(?:[.-](\d{2}))?$')
+
+
+# this will match any date of the form "day month_name year".
+year_last_re = re.compile('^(?:{1} )?'
+                          '({0})?(?: {1})?(?:,? )?'
+                          '(\d{{4}})$'.
+                          format('|'.join(all_months),
+                                 '(?:(\d{1,2})(?:st|nd|rd|th)?)'))
+
+# 'month_name modifier year' or 'modifier month/year/month_name'
+mod_date_re = re.compile('(?:({}) )?({}) ({})'.format(
+    '|'.join(all_months),
+    '|'.join(list(modifiers.keys())),
+    '|'.join(all_months + ['month', 'year'])))
+
+
+def daterange(year=None, month=None, day=None, timedelta=datetime.timedelta()):
+    """A helper function that returns a tuple with the starting and end date for
+    for the given range of dates. If called with empty arguments it will return
+    the current day as start and beginning. Otherwise day or month and day may
+    be omitted to get the whole month or whole year respectively. Timedelta is
+    only used if all other arguments are none and if it is set the dates that
+    will be returned are both 'today + timedelta'
+    """
+    year, month, day = map(lambda x: int(x) if x else None, (year, month, day))
+    if not (year or month or day):
+        date = datetime.date.today() + timedelta
+        return date, date
+    elif (not year) or (day and not month):
+        raise Exception
+    elif (not day) and (not month):
+        start = datetime.date(year, 1, 1)
+        end = datetime.date(year + 1, 1, 1)
+    elif (not day) and month:
+        start = datetime.date(year, month, 1)
+        end = datetime.date(year, month + 1, 1)
+    else:  # ~= if (year and month and day)
+        start = end = datetime.date(year, month, day)
+    return start, end
+
+
+def _parse_month(month):
+    """Parse the given month name (either the full name or its abbreviation)
+    to a number"""
+    month = months.index(month) if month in months[1:] else month
+    month = months_abbr.index(month) if month in months_abbr[1:] else month
+    return month
+
+
+def parse_date(string):
+    """"Tries to parse the given string into two date objects marking the
+    beginning and the end of the given period.
+
+    Example of supported formats:
+     - today, tomorrow, yesterday
+     - 2010-03-15, 2010.03, 2010 ('.' and '-' are possible delimiters)
+     - march 2010, mar 2010
+     - this month, last year, next year
+     - october this year, aug last year
+
+    Ranges of dates can be expressed in the following forms:
+     - start - end
+     - from start to end
+     - start to end
+    where start and end look like one of the above examples
+    """
+    is_range = is_range_re.match(string)
+    if is_range:
+        return (parse_date(is_range.group(1))[0],
+                parse_date(is_range.group(2))[1])
+    string = string.strip().lower()
+    if string == '':
+        return None, None
+
+    # check first if it is either yesterday, today or tomorrow
+    if string in rel_dates:
+        return daterange(timedelta=datetime.timedelta(days=rel_dates[string]))
+
+    # try to match
+    year_first = year_first_re.match(string)
+    if year_first:
+        year, month, day = year_first.group(1, 2, 3)
+        return daterange(year, month, day)
+
+    year_last = year_last_re.match(string)
+    if year_last:
+        month, year = year_last.group(2, 4)
+        day = year_last.group(1) or year_last.group(3)
+        return daterange(year, _parse_month(month), day)
+
+    mod_date = mod_date_re.match(string)
+    if mod_date:
+        today = datetime.date.today()
+        month, modifier, identifier = mod_date.group(1, 2, 3)
+        modifier = modifiers[modifier]
+        if identifier == 'year':
+            month = _parse_month(month) if month else None
+            return daterange(today.year + modifier, month)
+        if identifier == 'month':
+            m = today.replace(day=15) + modifier * datetime.timedelta(days=30)
+            return daterange(m.year, m.month)
+        else:
+            return daterange(today.year + modifier, _parse_month(identifier))
+
+
+if __name__ == '__main__':
+    today = datetime.date.today()
+    tests = {
+        'today': daterange(),
+        'yesterday': daterange(timedelta=datetime.timedelta(days=-1)),
+        'october 2010': daterange(2010, 10),
+        '2000': daterange(2000),
+        '1st february 2008': daterange(2008, 2, 1),
+        '2010-10': daterange(2010, 10),
+        '2000-01-03': daterange(2000, 1, 3),
+        'this year': daterange(today.year),
+        'august next year': daterange(today.year + 1, 8),
+        '2nd aug, 2010': daterange(2010, 8, 2),
+        'august 3rd, 2012': daterange(2012, 8, 3),
+    }
+    for test, result in tests.items():
+        assert parse_date(test) == result
+    print("passed all {} tests".format(len(tests)))


### PR DESCRIPTION
Allow any date and dateranges to be parsed and filtered to by the api. Adds a `dateparser` module that does the parsing.

Currently there is no nice way to input these dates, as the input form allows only to select the suggested years. Just a text input where any text can be input but that still has the list of suggestions would be nice. @aumayr: Maybe it's quickest if you could do this, as I don't know the frontend stuff very well.

The format of dates that can be parsed (from the docstring of dateparser.parse_date):

    Tries to parse the given string into two date objects marking the
    beginning and the end of the given period.

    Example of supported formats:
     - today, tomorrow, yesterday
     - 2010-03-15, 2010-03, 2010
     - march 2010, mar 2010
     - this month, last year, next year
     - october this year, aug last year

    Ranges of dates can be expressed in the following forms:
     - start - end
     - start to end
    where start and end look like one of the above examples

ref #25: partially implements this (all but the frontend part)
