### PR TITLE
Add "Year to Date" time filter

### DIFF
--- a/beancount_web/api.py
+++ b/beancount_web/api.py
@@ -210,8 +210,12 @@ class BeancountReportAPI(object):
         self.entries = self.all_entries
 
         if self.filters['time']:
+            time_filter = self.filters['time'].lower()
+            if time_filter == 'year to date':
+                time_filter = str(date.today().year) + ' - today'
+
             try:
-                begin_date, end_date = parse_date(self.filters['time'])
+                begin_date, end_date = parse_date(time_filter)
                 self.entries, _ = summarize.clamp_opt(self.entries, begin_date, end_date, self.options)
             except TypeError:
                 raise FilterException('Failed to parse date string: {}'.format(self.filters['time']))

--- a/beancount_web/application.py
+++ b/beancount_web/application.py
@@ -233,6 +233,28 @@ def utility_processor():
         args.update(kwargs)
         return url_for(request.endpoint, **args)
 
+    def search_suggestions(field_name):
+        if field_name == 'Time':
+            return {
+                'this month':'This Month',
+                '2015-03':'2015-03',
+                'march 2015':'March 2015',
+                'mar 2015':'Mar 2015',
+                'last year':'Last Year',
+                'aug last year':'Aug Last Year',
+                '2010-10 - 2014':'2010-10 - 2014',
+                'year to date':'Year to Date'
+            }
+        else:
+            return {}
+
+    def search_to_label(field_name, search):
+        suggestions = search_suggestions(field_name)
+        if search and search.lower() in suggestions:
+            return suggestions[search.lower()]
+        else:
+            return search or field_name
+
     def uptodate_eligible(account_name):
         if not 'uptodate-indicator-exclude-accounts' in app.user_config['beancount-web']:
             return False
@@ -253,6 +275,8 @@ def utility_processor():
 
     return dict(account_level=account_level,
                 url_for_current=url_for_current,
+                search_suggestions=search_suggestions,
+                search_to_label=search_to_label,
                 uptodate_eligible=uptodate_eligible)
 
 @app.context_processor

--- a/beancount_web/templates/_entry_filters.html
+++ b/beancount_web/templates/_entry_filters.html
@@ -1,26 +1,26 @@
 <form id="filter-form" action="{{ url_for_current() }}" method="GET">
     <ul class="topmenu">
+        {% set time_search_phrases = search_suggestions('Time') %}
         <li{% if g.filters['time'] %} class="selected"{% endif %}>
             <a href="{{ url_for_current(time=None) }}">
-                <span>{{ g.filters['time'] or 'Time' }}</span>
+                <span>{{ search_to_label('Time', g.filters['time']) }}</span>
             </a>
             <div class="filter" id="filter-time">
                 <div class="inputcontainer">
                     <input type="search">
                 </div>
                 <ul>
-                    {% set time_search_strings = ['this month', '2015-03', 'march 2015', 'mar 2015', 'last year', 'aug last year', '2010-10 - 2014'] %}
                     <li class="info">Supports search strings like
-                        {% for suggestion in time_search_strings %}
-                            {% if suggestion != g.filters['time'] %}
-                            <a href="{{ url_for_current(time=suggestion) }}" data-filter="{{ suggestion }}">{{ suggestion }}</a>{% if not loop.last %}, {% endif %}
+                        {% for search_phrase, suggestion in time_search_phrases.items() %}
+                            {% if search_phrase != g.filters['time'] %}
+                            <a href="{{ url_for_current(time=search_phrase) }}" data-filter="{{ search_phrase }}">{{ suggestion }}</a>{% if not loop.last %}, {% endif %}
                             {% endif %}
                         {% endfor %}
                     </li>
 
                     {% if g.filters['time'] and g.filters['time'] not in api.active_years|map('string') %}
                         <li class="suggestion selected" data-filter="{{ g.filters['time'] }}">
-                            <a href="{{ url_for_current(time=None) }}">{{ g.filters['time'] }}</a>
+                            <a href="{{ url_for_current(time=None) }}">{{ search_to_label('Time', g.filters['time']) }}</a>
                         </li>
                     {% endif %}
 


### PR DESCRIPTION
- In the API porting layer, translate "year to date" to "<current year> - today"
  (This ensures you can use it anywhere)
- Add "Year to Date" search suggestion in time filter
- Get the search suggestions from the code, instead of having them hardcoded in
  the template

Issue #82