### PR TITLE
Format Y-axis of charts (#86)

### DIFF
--- a/beancount_web/templates/charts/_chart_account_balance.html
+++ b/beancount_web/templates/charts/_chart_account_balance.html
@@ -2,6 +2,15 @@
     window.chartData.push({
         label: "Account balance",
         type: "line",
+        options: {
+            axisY: {
+                offset: 60,
+                position: 'end',
+                labelInterpolationFnc: function(value) {
+                    return value.toLocaleString()
+                }
+            }
+        },
         data: {
             series: [
                 {% for currency in operating_currencies %}

--- a/beancount_web/templates/charts/_chart_monthly_ie_changes.html
+++ b/beancount_web/templates/charts/_chart_monthly_ie_changes.html
@@ -3,7 +3,14 @@
         label: "Monthly changes (Income/Expenses)",
         type:  "bar",
         options: {
-            dateFormat: "MMM 'YY"
+            dateFormat: "MMM 'YY",
+            axisY: {
+                offset: 60,
+                position: 'end',
+                labelInterpolationFnc: function(value) {
+                    return value.toLocaleString()
+                }
+            }
         },
         data: {
             labels: [

--- a/beancount_web/templates/charts/_chart_monthly_net_worth.html
+++ b/beancount_web/templates/charts/_chart_monthly_net_worth.html
@@ -4,7 +4,14 @@
         label: "Net worth (in {{ currency }})",
         type: "line",
         options: {
-            dateFormat: "MMM 'YY"
+            dateFormat: "MMM 'YY",
+            axisY: {
+                offset: 60,
+                position: 'end',
+                labelInterpolationFnc: function(value) {
+                    return value.toLocaleString()
+                }
+            }
         },
         data: {
             series: [{
@@ -13,7 +20,7 @@
                     {% for row in net_worth.monthly_totals %}
                         {
                             x: new Date({{ row.end_date.year }}, {{ row.end_date.month-1 }}, {{ row.end_date.day }}),
-                            y: {{ row.totals[currency] }},
+                            y: {{ row.totals[currency] or 0 }},
                             meta: "{{ row.totals[currency]|format_currency }} {{ currency }}<br><em>{{ row.end_date.strftime('%Y-%m-%d') }}</em>"
                         },
                     {% endfor %}

--- a/beancount_web/templates/charts/_chart_monthly_totals.html
+++ b/beancount_web/templates/charts/_chart_monthly_totals.html
@@ -3,7 +3,14 @@
         label: "{{ label }}",
         type:  "bar",
         options: {
-            dateFormat: "MMM 'YY"
+            dateFormat: "MMM 'YY",
+            axisY: {
+                offset: 60,
+                position: 'end',
+                labelInterpolationFnc: function(value) {
+                    return value.toLocaleString()
+                }
+            }
         },
         data: {
             labels: [

--- a/beancount_web/templates/charts/_chart_yearly_totals.html
+++ b/beancount_web/templates/charts/_chart_yearly_totals.html
@@ -3,7 +3,14 @@
         label: "{{ label }}",
         type:  "bar",
         options: {
-            dateFormat: "YYYY"
+            dateFormat: "YYYY",
+            axisY: {
+                offset: 60,
+                position: 'end',
+                labelInterpolationFnc: function(value) {
+                    return value.toLocaleString()
+                }
+            }
         },
         data: {
             labels: [


### PR DESCRIPTION
- Format the numbers on the Y-axis of various charts to have thousands separators
- Fix bug in net-worth chart where missing data caused the chart to fail to render

Issue #86