### PR TITLE
Add `use_external_editor` option

### DIFF
--- a/beancount_web/application.py
+++ b/beancount_web/application.py
@@ -233,6 +233,17 @@ def utility_processor():
         args.update(kwargs)
         return url_for(request.endpoint, **args)
 
+    def url_for_source(**kwargs):
+        args = request.view_args.copy()
+        args.update(kwargs)
+        if app.user_config['beancount-web'].getboolean('use-external-editor'):
+            if 'line' in args:
+                return "beancount://%(file_path)s?lineno=%(line)d" % args
+            else:
+                return "beancount://%(file_path)s" % args
+        else:
+            return url_for('source', **args)
+
     def search_suggestions(field_name):
         if field_name == 'Time':
             return [
@@ -268,6 +279,7 @@ def utility_processor():
 
     return dict(account_level=account_level,
                 url_for_current=url_for_current,
+                url_for_source=url_for_source,
                 search_suggestions=search_suggestions,
                 uptodate_eligible=uptodate_eligible)
 

--- a/beancount_web/default-settings.conf
+++ b/beancount_web/default-settings.conf
@@ -51,3 +51,6 @@ uptodate-indicator-exclude-accounts =
 ; If present the cursor will be positioned above the insert marker and two
 ; newlines will be inserted
 ; editor-insert-marker = \;\;\; INSERT
+
+; If True, instead of using the internal editor, the 'beancount://' URI scheme is used
+use-external-editor = False

--- a/beancount_web/templates/_account_name_header.html
+++ b/beancount_web/templates/_account_name_header.html
@@ -20,7 +20,7 @@
     {% set activity = api.statistics(account_name=account_name) %}
     {% if activity %}
     <div class="last-activity">
-        (Last entry: <a href="{{ url_for('source', file_path=activity.last_posting_filename, line=activity.last_posting_lineno) }}" title="Show source {{ activity.last_posting_filename }}:{{ activity.last_posting_lineno }}">{{ activity.last_posting_date }}</a>)
+        (Last entry: <a href="{{ url_for_source(file_path=activity.last_posting_filename, line=activity.last_posting_lineno) }}" title="Show source {{ activity.last_posting_filename }}:{{ activity.last_posting_lineno }}">{{ activity.last_posting_date }}</a>)
     </div>
     {% endif %}
 </h1>

--- a/beancount_web/templates/context.html
+++ b/beancount_web/templates/context.html
@@ -16,7 +16,7 @@
             <dt>Hash:</dt>
             <dd><code>{{ context_.hash }}</code></dd>
             <dt>Location:</dt>
-            <dd><code><a href="{{ url_for('source', file_path=context_.filename, line=context_.line) }}" title="Show source {{ context_.filename }}:{{ context_.line }}">{{ context_.filename }}:{{ context_.line }}</a></code></dd>
+            <dd><code><a href="{{ url_for_source(file_path=context_.filename, line=context_.line) }}" title="Show source {{ context_.filename }}:{{ context_.line }}">{{ context_.filename }}:{{ context_.line }}</a></code></dd>
         </dl>
         <div class="editor-wrapper editor-wrapper-readonly">
             <div class="editor editor-readonly" id="editor-{{ context.hash }}">

--- a/beancount_web/templates/errors.html
+++ b/beancount_web/templates/errors.html
@@ -17,7 +17,7 @@
             <tbody>
                 {% for error in errors %}
                 <tr>
-                    {% with link=url_for('source', file_path=error.file, line=error.line) %}
+                    {% with link=url_for_source(file_path=error.file, line=error.line) %}
                     <td><a class="source" href="{{ link }}" title="Show source {{ error.file }}:{{ error.line }}">{{ error.file }}</a></td>
                     <td class="num"><a class="source" href="{{ link }}" title="Show source {{ error.file }}:{{ error.line }}">{{ error.line }}</a></td>
                     <td>{{ error.error }}</td>

--- a/beancount_web/templates/event_detail.html
+++ b/beancount_web/templates/event_detail.html
@@ -49,7 +49,7 @@
                 {% for event in events %}
                     <tr>
                         <td>
-                            <a href="{{ url_for('source', file_path=event.meta.filename, line=event.meta.lineno) }}" title="Show source {{ event.meta.filename }}:{{ event.meta.lineno }}">{{ event.date }}</a>
+                            <a href="{{ url_for_source(file_path=event.meta.filename, line=event.meta.lineno) }}" title="Show source {{ event.meta.filename }}:{{ event.meta.lineno }}">{{ event.date }}</a>
                         </td>
                         <td>{{ event.type }}</td>
                         <td>{{ event.description }}</td>

--- a/beancount_web/templates/events.html
+++ b/beancount_web/templates/events.html
@@ -56,7 +56,7 @@
                 {% for event in events %}
                     <tr>
                         <td>
-                            <a href="{{ url_for('source', file_path=event.meta.filename, line=event.meta.lineno) }}" title="Show source {{ event.meta.filename }}:{{ event.meta.lineno }}">{{ event.date }}</a>
+                            <a href="{{ url_for_source(file_path=event.meta.filename, line=event.meta.lineno) }}" title="Show source {{ event.meta.filename }}:{{ event.meta.lineno }}">{{ event.date }}</a>
                         </td>
                         <td><a href="{{ url_for('event_details', event_type=event.type) }}" title="Show events of type '{{ event.type }}'">{{ event.type }}</a></td>
                         <td>{{ event.description }}</td>

--- a/beancount_web/templates/source.html
+++ b/beancount_web/templates/source.html
@@ -7,6 +7,24 @@
 
 {% block content %}
     <h1>Source</h1>
+    {% if config.getboolean('use-external-editor') %}
+    <table class="errors sortable">
+        <thead>
+            <tr>
+                <th data-sort="string" class="sorting-asc">File</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for source_file in api.source_files() %}
+            <tr>
+                {% with link=url_for_source(file_path=source_file) %}
+                <td><a class="source" href="{{ link }}" title="Show source {{ source_file }}">{{ source_file }}</a></td>
+                {% endwith %}
+             </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
     <form class="editor-source" action="{{ url_for('source') }}" method="get">
         <select name="file_path">
             {% for source_file in api.source_files() %}
@@ -20,4 +38,5 @@
     <form class="editor-save" action="{{ url_for('source') }}" method="post">
         <input type="submit" value="Save">
     </form>
+    {% endif %}
 {% endblock %}

--- a/beancount_web/templates/statistics.html
+++ b/beancount_web/templates/statistics.html
@@ -57,7 +57,7 @@
                         {% else %}
                         <td></td>
                         {% endif %}
-                        <td><a href="{{ url_for('source', file_path=activity.last_posting_filename, line=activity.last_posting_lineno) }}" title="Show source {{ activity.last_posting_filename }}:{{ activity.last_posting_lineno }}">{{ activity.last_posting_date }}</a></td>
+                        <td><a href="{{ url_for_source(file_path=activity.last_posting_filename, line=activity.last_posting_lineno) }}" title="Show source {{ activity.last_posting_filename }}:{{ activity.last_posting_lineno }}">{{ activity.last_posting_date }}</a></td>
                     </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
Add `use_external_editor` option that, when set to `True`, will cause
links to source files to open in an external editor.

This requires that:
1. `beancount-web` is running locally
2. The user has access to the source files
3. A content handler for the URI scheme `beancount://` is installed