### PR TITLE
Hide filters on specific pages (issue #97)

### DIFF
--- a/beancount_web/templates/_layout.html
+++ b/beancount_web/templates/_layout.html
@@ -22,6 +22,7 @@
     ])
 ] %}
 {% set active_page = active_page|default('journal') %}
+{% set show_filters = show_filters|default(True) %}
 <!doctype html>
 <html>
 <head>
@@ -57,9 +58,11 @@
             <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAMAAABF0y+mAAAAsVBMVEUAAAD///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////+3mHKcAAAAOnRSTlMAAQMEBQYHCAwNDg8QExkaISImJzQ7RUZHSUtVZGtsb3FzdXd4f5WYm56jr7y+xcfP2tze4OLk6/X9+wsXVgAAAMJJREFUKFPFkWkTgiAYhDG1wy677VSzw0q6pKz3//+wBGRkGO2r+4ndZ9hhFoQq0AaXKZoiKFfE4Uzt82iKOWyrcJjDJU90N45dnZ/3HCbrPvfmE64YHkZ216MQi6rwPUBp0VF4GVrQowlAqwA6cN8xKJ4uwyDNGdz+g0EBnAvoFEALxjZC9gIsCd60zJy6ZqpRmFmNLfQ9NJirE7pWbDLTuYj5SI0Fhk+IzwdqfvLhJ0jRSvqVl/rRCYdnKNVG7atcP+gmOQsBuK8NAAAAAElFTkSuQmCC" alt="">
             <h1 class="site-name">{{ title or 'Beancount Web' }}</h1>
         </div>
+        {% if show_filters %}
         <nav>
             {% include "_entry_filters.html" %}
         </nav>
+        {% endif %}
     </header>
     <div class="main">
         <aside>

--- a/beancount_web/templates/errors.html
+++ b/beancount_web/templates/errors.html
@@ -1,5 +1,6 @@
 {% extends "_layout.html" %}
 {% set active_page = 'errors' %}
+{% set show_filters = False %}
 
 {% block title %}Errors{% endblock %}
 

--- a/beancount_web/templates/options.html
+++ b/beancount_web/templates/options.html
@@ -1,5 +1,6 @@
 {% extends "_layout.html" %}
 {% set active_page = 'options' %}
+{% set show_filters = False %}
 
 {% block title %}Options{% endblock %}
 

--- a/beancount_web/templates/query.html
+++ b/beancount_web/templates/query.html
@@ -1,5 +1,6 @@
 {% extends "_layout.html" %}
 {% set active_page = 'query' %}
+{% set show_filters = False %}
 
 {% block title %}Custom Query{% endblock %}
 

--- a/beancount_web/templates/source.html
+++ b/beancount_web/templates/source.html
@@ -1,5 +1,6 @@
 {% extends "_layout.html" %}
 {% set active_page = 'source' %}
+{% set show_filters = False %}
 
 {% block title %}Source{% endblock %}
 


### PR DESCRIPTION
Filters were shown on all pages, even those where they didn't make
sense or do anything. This removes the filters from pages such as
`Custom Query`, `Source`, `Options`, and `Errors`.

Issue #97