### PR TITLE
Prevent metadata keys from linewrapping

### DIFF
--- a/beancount_web/static/sass/styles.scss
+++ b/beancount_web/static/sass/styles.scss
@@ -628,11 +628,14 @@ article {
                         }
 
                         dt {
-                            width: 0;
                             min-width: 65px;
                             font-weight: normal;
                             font-style: italic;
                             color: #85AACF;
+                        }
+
+                        dt::after {
+                            content: ":\00a0\00a0";
                         }
 
                         dd a {
@@ -720,7 +723,6 @@ article {
 
         dt {
             display: inline-block;
-            width: 120px;
             float: left;
             font-weight: bold;
         }

--- a/beancount_web/static/stylesheets/styles.css
+++ b/beancount_web/static/stylesheets/styles.css
@@ -1026,11 +1026,13 @@ article table.journal-table tr.has-metadata dl.metadata dt:last-child, article t
 }
 /* line 630, ../sass/styles.scss */
 article table.journal-table tr.has-metadata dl.metadata dt {
-  width: 0;
   min-width: 65px;
   font-weight: normal;
   font-style: italic;
   color: #85AACF;
+}
+article table.journal-table tr.has-metadata dl.metadata dt::after {
+    content: ":\00a0\00a0";
 }
 /* line 638, ../sass/styles.scss */
 article table.journal-table tr.has-metadata dl.metadata dd a {
@@ -1120,7 +1122,6 @@ article dl {
 /* line 721, ../sass/styles.scss */
 article dl dt {
   display: inline-block;
-  width: 120px;
   float: left;
   font-weight: bold;
 }


### PR DESCRIPTION
Originally, long keys in metadata would line-wrap, causing the following keys to be indented. This caused an incomprehensible mess when you've got multiple pieces of metadata on one item.

Remove the `width` directives, and add some separation between keys and values with content (`:  `)