### PR TITLE
Display beancount `Query` directives in `Custom Query` (#96)

### DIFF
--- a/beancount_web/api/__init__.py
+++ b/beancount_web/api/__init__.py
@@ -29,7 +29,7 @@ from beancount.core.interpolate import compute_entries_balance
 from beancount.core.account import has_component
 from beancount.core.account_types import get_account_sign
 from beancount.core.data import get_entry, posting_sortkey, Open, Close, Note,\
-                                Document, Balance, Transaction, Pad, Event
+                                Document, Balance, Transaction, Pad, Event, Query
 from beancount.core.number import ZERO
 from beancount.ops import prices, holdings, summarize
 from beancount.parser import options
@@ -423,6 +423,17 @@ class BeancountReportAPI(object):
 
     def notes(self):
         return self._journal_for_postings(self.entries, Note)
+
+    def queries(self, qname = None):
+        res = self._journal_for_postings(self.entries, Query)
+        no_query = {
+            'name': 'None',
+            'query_string': ''
+        }
+        if qname:
+            return next( (x for x in res if x['name'] == qname), no_query)
+        else:
+            return res
 
     def events(self, event_type=None, only_include_newest=False):
         events = self._journal_for_postings(self.entries, Event)

--- a/beancount_web/application.py
+++ b/beancount_web/application.py
@@ -105,9 +105,18 @@ def context(ehash=None):
     # TODO handle errors
     return render_template('context.html', context=context)
 
+@app.route('/query/stored_queries/<string:stored_query>')
+def get_stored_query(stored_query=None):
+    bql = app.api.queries(stored_query)['query_string']
+    if request.is_xhr:
+        return bql
+    else:
+        return redirect(url_for('query', bql=bql, selected_query=stored_query))
+
 @app.route('/query/')
-def query(bql=None):
-    query = bql if bql else request.args.get('bql', None)
+def query(bql=None, selected_query=None):
+    selected_query = selected_query or request.args.get('selected_query') or ''
+    query = bql or request.args.get('bql') or app.api.queries(selected_query)['query_string']
     error = None
     result = None
 
@@ -118,7 +127,7 @@ def query(bql=None):
             result = None
             error = e
 
-    return render_template('query.html', query=query, result=result, error=error)
+    return render_template('query.html', query=query, result=result, selected_query=selected_query, error=error)
 
 @app.route('/journal/')
 def journal():

--- a/beancount_web/default-settings.conf
+++ b/beancount_web/default-settings.conf
@@ -20,6 +20,7 @@ journal-show-type-note = True
 journal-show-type-document = True
 journal-show-type-pad = False
 journal-show-type-padding = False
+journal-show-type-query = False
 
 ; If True changes and balances will be shown in the General Journal view
 journal-general-show-balances = False

--- a/beancount_web/static/javascript/editor.js
+++ b/beancount_web/static/javascript/editor.js
@@ -48,6 +48,18 @@ $(document).ready(function() {
             $button.attr('disabled', 'disabled').attr('value', 'Submitting query...');
             window.location.href = $button.parents('form').attr('action') + "?bql=" + encodeURIComponent(editor.getValue());
         });
+
+        $('.stored-queries select').change(function() {
+            var selected_id_url = $(this).val();
+            if (selected_id_url != "") {
+                $.get(selected_id_url)
+                .done(function(data) {
+                    editor.setValue(data, -1);
+                });
+            } else {
+                editor.setValue("", -1);
+            }
+        });
     };
 
     // The /source/ editor

--- a/beancount_web/static/javascript/journal.js
+++ b/beancount_web/static/javascript/journal.js
@@ -34,6 +34,10 @@ Handlebars.registerHelper('account_url', function (accountName) {
     return window.accountURL.replace("REPLACEME", accountName);
 });
 
+Handlebars.registerHelper('query_url', function (queryName) {
+    return window.queryURL.replace("REPLACEME", queryName);
+});
+
 Handlebars.registerHelper('tag_url', function (tagName) {
     return window.tagURL.replace("REPLACEME", tagName);
 });

--- a/beancount_web/static/sass/styles.scss
+++ b/beancount_web/static/sass/styles.scss
@@ -558,6 +558,10 @@ article {
                     background-color: $color_sail_approx;
                 }
 
+                &.query {
+                    background-color: $color_sail_approx;
+                }
+
                 &.document {
                     background-color: $color_pink_lace_approx;
 
@@ -858,6 +862,17 @@ article#page-query {
         line-height: 1.3em;
         font-weight: bold;
         font-family: $font_family_monospaced;
+    }
+
+    .stored-queries {
+        color: #666;
+        font-size: 1px;
+        float: right;
+        margin-bottom: 10px;
+    }
+
+    .editor-wrapper {
+        clear: right;
     }
 
     .sample {

--- a/beancount_web/static/stylesheets/styles.css
+++ b/beancount_web/static/stylesheets/styles.css
@@ -773,6 +773,9 @@ article table.journal-table tr.close {
 article table.journal-table tr.note {
   background-color: #aad0ff;
 }
+article table.journal-table tr.query {
+  background-color: #aad0ff;
+}
 article table.journal-table tr.document {
   background-color: #ffc8ff;
 }
@@ -1982,6 +1985,15 @@ article#page-query .error {
   line-height: 1.3em;
   font-weight: bold;
   font-family: monospace;
+}
+article#page-query .stored-queries {
+    color: #666;
+    font-size: 11px;
+    float: right;
+    margin-bottom: 10px;
+}
+article#page-query .editor-wrapper {
+    clear: right;
 }
 article#page-query .sample h3, article#page-query .sample li, article#page-query .sample code {
   color: #AAA;

--- a/beancount_web/templates/_journal_table.html
+++ b/beancount_web/templates/_journal_table.html
@@ -5,7 +5,8 @@
                       ('note',        config.getboolean('journal-show-type-note')),
                       ('document',    config.getboolean('journal-show-type-document')),
                       ('pad',         config.getboolean('journal-show-type-pad')),
-                      ('padding',     config.getboolean('journal-show-type-padding'))] %}
+                      ('padding',     config.getboolean('journal-show-type-padding')),
+                      ('query',       config.getboolean('journal-show-type-query'))] %}
 
 {% if show_tablefilter %}
     <div class="table-filter">
@@ -23,6 +24,7 @@
 <script>
     window.contextURL = "{{ url_for('context', ehash='REPLACEME')|safe }}";
     window.accountURL = "{{ url_for('account_with_journal', name='REPLACEME')|safe }}";
+    window.queryURL = "{{ url_for('query', selected_query='REPLACEME')|safe }}";
     window.tagURL = "{{ url_for_current(tag='REPLACEME')|safe }}";
     window.documentURL = "{{ url_for('document', file_path='REPLACEME')|safe }}";
     window.journalURL = "{{ url_for('journal')|safe }}";
@@ -72,6 +74,9 @@
                     {{/ifCond}}
                     {{#ifCond meta.type '==' 'note'}}
                         Note: {{ comment }}
+                    {{/ifCond}}
+                    {{#ifCond meta.type '==' 'query'}}
+                        Query: <a href="{{ query_url name }}">{{ name }}</a>
                     {{/ifCond}}
                     {{#ifCond meta.type '==' 'pad'}}
                         Pad <a href="{{ account_url account }}">{{ account }}</a> from <a href="{{ account_url source_account }}">{{ source_account }}</a>

--- a/beancount_web/templates/query.html
+++ b/beancount_web/templates/query.html
@@ -14,6 +14,16 @@
         {# TODO Add some sample queries #}
     </p>
 
+    <div class="stored-queries">
+        <label for="stored-queries">Load stored query:</label>
+        <select id="stored-queries">
+            <option value=""></option>
+            {% for query in api.queries() %}
+                <option value="{{ url_for('get_stored_query', stored_query=query['name']) }}"{% if query['name'] == selected_query %} selected="selected"{% endif %}>{{ query['name'] }}</option>
+            {% endfor %}
+        </select>
+    </div>
+
     <form action="{{ url_for('query') }}" method="get">
         <div class="editor-wrapper editor-wrapper-query">
             <div class="editor" id="editor-query"><pre><code>{{ query or '' }}</code></pre></div>

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(name='beancount-web',
       license='MIT',
       packages=['beancount_web',
                 'beancount_web.util',
+                'beancount_web.api',
                 'beancount_urlscheme'],
       include_package_data=True,
       entry_points={


### PR DESCRIPTION
This implements @yagebu 's suggestion (in #96) to use the `Query` directive that's currently an experimental feature in beancount itself. This allows storing "canned" queries within the beancount source-file.

This pulls the "canned" queries from the source-file and displays them in a dropdown box in `Custom Query`. To add queries, add the following to the source file (I put them in a separate included file):

```beancount
option "experiment_query_directive" "TRUE"

2015-01-01 query "Expenses per Month" "
SELECT
  MONTH(date) AS month,
  SUM(COST(position)) AS balance
WHERE
   account ~ 'Expenses:' AND
   currency = 'CNY' AND
   YEAR(date) = 2015
GROUP BY 1
ORDER BY 1;
"
```