### PR TITLE
Retain stored query after submitting

### DIFF
--- a/beancount_web/static/javascript/editor.js
+++ b/beancount_web/static/javascript/editor.js
@@ -46,7 +46,13 @@ $(document).ready(function() {
             event.stopImmediatePropagation();
             var $button = $(this);
             $button.attr('disabled', 'disabled').attr('value', 'Submitting query...');
-            window.location.href = $button.parents('form').attr('action') + "?bql=" + encodeURIComponent(editor.getValue());
+            var nextUrl = $button.parents('form').attr('action') + "?bql=" + encodeURIComponent(editor.getValue());
+            var storedQuerySelectedIndex = $('.stored-queries select').prop('selectedIndex');
+            if (storedQuerySelectedIndex > 0) {
+                var storedQueryHash = $('.stored-queries select option:nth-child(' + (storedQuerySelectedIndex + 1) + ')').attr('data-stored-query-hash');
+                nextUrl = nextUrl + '&query_hash=' + storedQueryHash;
+            }
+            window.location.href = nextUrl;
         });
 
         $('.stored-queries select').change(function() {

--- a/beancount_web/templates/query.html
+++ b/beancount_web/templates/query.html
@@ -24,7 +24,7 @@
             <select id="stored-queries">
                 <option value=""></option>
                 {% for query in api.queries() %}
-                    <option value="{{ url_for('get_stored_query', stored_query_hash=query['hash']) }}"{% if query['hash'] == query_hash %} selected="selected"{% endif %}>{{ query['name'] }}</option>
+                    <option value="{{ url_for('get_stored_query', stored_query_hash=query['hash']) }}" data-stored-query-hash="{{query['hash']}}"{% if query['hash'] == query_hash %} selected="selected"{% endif %}>{{ query['name'] }}</option>
                 {% endfor %}
             </select>
         </div>


### PR DESCRIPTION
When pressing `Submit` after selecting a stored query, the select-box
is cleared in the result page.

Same issue as in 25401b96