### PR TITLE
Beancount queries syntax highlighting

### DIFF
--- a/beancount_web/static/sass/_editor.scss
+++ b/beancount_web/static/sass/_editor.scss
@@ -49,7 +49,7 @@
         font-weight: bold;
     }
 
-    .ace_class, .ace_double {
+    .ace_class, .ace_double, .ace_triple {
         color: #bb8844;
     }
 

--- a/beancount_web/static/stylesheets/styles.css
+++ b/beancount_web/static/stylesheets/styles.css
@@ -1003,7 +1003,7 @@ article .left.statistics table.statistics td:first-child a {
   color: #333;
   font-weight: bold;
 }
-.ace_editor.ace-chrome .ace_class, .ace_editor.ace-chrome .ace_double {
+.ace_editor.ace-chrome .ace_class, .ace_editor.ace-chrome .ace_double, .ace_editor.ace-chrome .ace_triple {
   color: #bb8844;
 }
 .ace_editor.ace-chrome .ace_constant.ace_numeric.ace_date {

--- a/beancount_web/static/vendor/ace-js/mode-beancount.js
+++ b/beancount_web/static/vendor/ace-js/mode-beancount.js
@@ -3,6 +3,7 @@ define("ace/mode/beancount_highlight_rules",["require","exports","module","ace/l
 
 var oop = require("../lib/oop");
 var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+var SqlHighlightRules = require("ace/mode/sql_highlight_rules").SqlHighlightRules;
 
 var BeancountHighlightRules = function() {
 
@@ -16,8 +17,13 @@ var BeancountHighlightRules = function() {
             regex: /^#!.*/,
             comment: "Shebangs"
         }, {
+            token: "string.quoted.triple.beancount",
+            regex: /"""/,
+            comment: "Multi-line strings (embedded SQL)",
+            next: "sql-start"
+        }, {
             token: "string.quoted.double.beancount",
-            regex: /\".*\"/,
+            regex: /"[^"]*"/,
             comment: "strings"
         }, {
             token: [
@@ -71,7 +77,7 @@ var BeancountHighlightRules = function() {
                 "text",
                 "support.function.directive.beancount"
             ],
-            regex: /([0-9]{4})(\-)([0-9]{2})(\-)([0-9]{2})(\s)(open|close|pad|balance|note|price|event|document|commodity)/,
+            regex: /([0-9]{4})(\-)([0-9]{2})(\-)([0-9]{2})(\s)(open|close|pad|balance|note|price|event|document|commodity|query)/,
             comment: "Dated directives"
         }, {
             token: [
@@ -143,6 +149,13 @@ var BeancountHighlightRules = function() {
             comment: "Commented text"
         }]
     }
+
+    this.embedRules(SqlHighlightRules, "sql-", [{
+        token: "string.quoted.triple.beancount",
+        regex: /"""/,
+        comment: "Multi-line strings",
+        next: "start"
+    }]);
 
     this.normalizeRules();
 };


### PR DESCRIPTION
Syntax highlighting for `Queries`
    
- Highlight the `query` directive
- Highlight multiline strings (`""" ... """`) as SQL (triple-quoted strings are as of yet not supported by the beancount parser)

Issue #96