### PR TITLE
Make journal more consistent with bean-web; simplify holdings table

### DIFF
--- a/beancount_web/api/__init__.py
+++ b/beancount_web/api/__init__.py
@@ -369,7 +369,8 @@ class BeancountReportAPI(object):
         return events
 
     def holdings(self):
-        return holdings_reports.report_holdings(None, False, self.entries, self.options)
+        holdings_list, _ = holdings_reports.get_assets_holdings(self.entries, self.options)
+        return holdings_list
 
     def _net_worth_in_periods(self):
         month_tuples = self._interval_tuples('month', self.entries)

--- a/beancount_web/templates/holdings.html
+++ b/beancount_web/templates/holdings.html
@@ -4,7 +4,7 @@
 {% block title %}Equity/Holdings{% endblock %}
 
 {% macro num_cell(value) -%}
-<td class="num" data-sort-value="{{ value|replace(',', '')|float }}">{% if value %}{{ value|replace(',', '')|float|format_currency }}{% endif %}</td>
+<td class="num" data-sort-value="{{ value }}">{% if value %}{{ value|format_currency }}{% endif %}</td>
 {%- endmacro %}
 
 {% block content %}
@@ -24,20 +24,20 @@
             </tr>
         </thead>
         <tbody>
-            {% for holding in holdings.body %}
+            {% for holding in holdings %}
             <tr>
                 <td>
-                    {% with account_name=holding.0 %}
+                    {% with account_name=holding.account %}
                         {% include "_account_name.html" %}
                     {% endwith %}
                 </td>
-                {{ num_cell(holding.1) }}
-                <td>{{ holding.2 }}</td>
-                <td>{{ holding.3 }}</td>
-                {{ num_cell(holding.4) }}
-                {{ num_cell(holding.5) }}
-                {{ num_cell(holding.6) }}
-                {{ num_cell(holding.7) }}
+                {{ num_cell(holding.number) }}
+                <td>{{ holding.currency}}</td>
+                <td>{{ holding.cost_currency }}</td>
+                {{ num_cell(holding.cost_number) }}
+                {{ num_cell(holding.price_number) }}
+                {{ num_cell(holding.book_value) }}
+                {{ num_cell(holding.market_value) }}
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
[Removed from the PR]: The first commit let's beancount do the rendering of price, cost and position. If we do it in javascript, we might lose information (like the cost declaration of a lot). Also, the balance columns now shows the total balance of the account, which makes a lot more sense to me and is also how `bean-web` does it.

The second change is as discussed in 4fca095bde527bb9e8e66f83daf6ca41761b1bfb.